### PR TITLE
feat: add secure environment configuration setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# OpenRouter API credentials
+OPENROUTER_API_KEY=your_openrouter_api_key
+
+# Pinecone credentials
+PINECONE_API_KEY=your_pinecone_api_key
+PINECONE_ENVIRONMENT=your_pinecone_environment

--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ retrieval techniques and emphasizes strong security practices to address existin
 technical debt and code duplication.
 
 ## Setup Instructions
-1. Install Python 3.11 or later.
-2. Create a virtual environment and activate it:
-   `python3 -m venv .venv && source .venv/bin/activate`
+1. Install Python **3.11**.
+2. Create and activate a virtual environment:
+   `python3.11 -m venv .venv && source .venv/bin/activate`
 3. Install dependencies:
    `pip install -r requirements.txt`
 4. Configure environment variables by copying `.env.example` to `.env` and
-   providing keys such as `OPENROUTER_API_KEY`. Never commit secrets.
-5. Start the application with `python src/main.py` after configuration.
+   setting values for `OPENROUTER_API_KEY`, `PINECONE_API_KEY`, and
+   `PINECONE_ENVIRONMENT`.
+5. Environment variables are loaded securely via `src/config/env_loader.py`,
+   which validates required keys before use.
+6. Start the application with `python src/main.py` after configuration.
 
 ## Contribution Guidelines
 - Follow PEP 8 formatting with a maximum line length of 100 characters and keep
@@ -29,4 +32,3 @@ technical debt and code duplication.
   committing.
 - Use Conventional Commits for messages and ensure branches are up to date with
   `main`.
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+gradio>=4.0.0
+pinecone-client>=3.0.0
+sentence-transformers>=2.2.2
+openai>=1.0.0
+langchain>=0.1.0
+python-dotenv>=1.0.0
+
+# Testing and code quality tools
+pytest>=7.0
+pytest-asyncio>=0.21
+mypy>=1.0
+black>=23.0
+flake8>=6.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for the Super Chatbot Personal project."""

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration utilities for secure environment variable management."""
+
+from .env_loader import ConfigurationError, load_env
+
+__all__ = ["ConfigurationError", "load_env"]

--- a/src/config/env_loader.py
+++ b/src/config/env_loader.py
@@ -1,0 +1,45 @@
+"""Utilities for securely loading required environment variables."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Dict, Iterable
+
+from dotenv import load_dotenv
+
+
+class ConfigurationError(Exception):
+    """Raised when required environment configuration is missing or invalid."""
+
+
+async def load_env(required_vars: Iterable[str]) -> Dict[str, str]:
+    """Load and validate environment variables asynchronously.
+
+    Args:
+        required_vars: Names of required environment variables.
+
+    Returns:
+        Mapping of variable names to their resolved values.
+
+    Raises:
+        ConfigurationError: If any required variable is missing or invalid.
+    """
+
+    vars_list = list(required_vars)
+    if not all(isinstance(var, str) and var for var in vars_list):
+        raise ConfigurationError(
+            "required_vars must contain non-empty strings"  # noqa: E501
+        )
+
+    await asyncio.to_thread(load_dotenv, Path(".env"))
+
+    resolved: Dict[str, str] = {}
+    for var in vars_list:
+        value = os.getenv(var)
+        if value is None or not value.strip():
+            raise ConfigurationError(f"Missing environment variable: {var}")
+        resolved[var] = value
+
+    return resolved

--- a/tests/test_env_loader.py
+++ b/tests/test_env_loader.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+import pytest  # noqa: E402
+from src.config import ConfigurationError, load_env  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_load_env_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENROUTER_API_KEY=ok\nPINECONE_API_KEY=pk\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("PINECONE_API_KEY", raising=False)
+
+    result = await load_env(["OPENROUTER_API_KEY", "PINECONE_API_KEY"])
+    assert result == {"OPENROUTER_API_KEY": "ok", "PINECONE_API_KEY": "pk"}
+
+
+@pytest.mark.asyncio
+async def test_load_env_missing_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENROUTER_API_KEY=ok\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PINECONE_API_KEY", raising=False)
+
+    with pytest.raises(ConfigurationError):
+        await load_env(["OPENROUTER_API_KEY", "PINECONE_API_KEY"])
+
+
+@pytest.mark.asyncio
+async def test_load_env_invalid_input() -> None:
+    with pytest.raises(ConfigurationError):
+        await load_env([""])


### PR DESCRIPTION
## Summary
- add project requirements file
- provide env loader and example secrets file
- document Python 3.11 setup and secure config usage

## Testing
- `pip install -q -r requirements.txt`
- `black src tests`
- `flake8 src tests`
- `mypy src`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb2c71ab08322bfc5f6b409a34b9c