### PR TITLE
fix: handle embedder and index failures

### DIFF
--- a/src/chat_interface.py
+++ b/src/chat_interface.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
-from typing import List
+import asyncio
+from typing import Awaitable, Callable, List, TypeVar
 
 import gradio as gr  # type: ignore[import-not-found]
 
 from .embedder import BgeEmbedder
 from .exceptions import ChatError
 from .pinecone_index import PineconeIndex
+
+T = TypeVar("T")
+
+
+async def _with_retry(
+    func: Callable[[], Awaitable[T]], retries: int = 3, timeout: int = 10
+) -> T:
+    """Execute an async function with retry and timeout."""
+    for attempt in range(retries):
+        try:
+            return await asyncio.wait_for(func(), timeout=timeout)
+        except Exception:
+            if attempt == retries - 1:
+                raise
+            await asyncio.sleep(0.5)
 
 
 async def handle_message(
@@ -17,8 +33,14 @@ async def handle_message(
     """Respond to a user query using Dense X Retrieval."""
     if not isinstance(message, str) or not message.strip():
         raise ChatError("message must be a non-empty string")
-    vectors = await embedder.embed([message])
-    results = await index.query(vectors[0])
+    try:
+        vectors = await _with_retry(lambda: embedder.embed([message]))
+    except Exception as exc:  # noqa: BLE001
+        raise ChatError("embedding failed") from exc
+    try:
+        results = await _with_retry(lambda: index.query(vectors[0]))
+    except Exception as exc:  # noqa: BLE001
+        raise ChatError("index query failed") from exc
     if not results:
         return "No results found."
     return results[0]["metadata"].get("text", "")


### PR DESCRIPTION
## Summary
- add retry/timeout helper for async operations
- wrap embedder and index calls with ChatError handling
- test embedder and index failure scenarios

## Testing
- `black src tests`
- `mypy src/` *(fails: command hung, interrupted)*
- `flake8 --max-line-length=100 src/chat_interface.py tests/test_chat_interface.py`
- `python scripts/check_code_quality.py` *(fails: No such file or directory)*
- `pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68add33a35c88322b0097da363446411