### PR TITLE
feat: add application startup and smoke test

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -33,3 +33,7 @@ class CitationError(Exception):
 
 class RetryError(Exception):
     """Raised when an operation exceeds retry attempts."""
+
+
+class InitializationError(Exception):
+    """Raised when application startup fails."""

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,56 @@
+"""Application startup for the Gradio chat interface."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Sequence
+
+import gradio as gr  # type: ignore[import-not-found]
+
+from .chat_interface import build_interface
+from .config import ConfigurationError, load_env
+from .embedder import BgeEmbedder
+from .exceptions import InitializationError
+from .pinecone_index import PineconeIndex
+
+REQUIRED_ENV_VARS: Sequence[str] = ("PINECONE_API_KEY", "PINECONE_INDEX_NAME")
+
+
+async def startup() -> gr.ChatInterface:
+    """Initialize components and build the Gradio interface.
+
+    Returns:
+        Configured Gradio ChatInterface.
+
+    Raises:
+        InitializationError: If environment loading or component setup fails.
+    """
+    try:
+        await load_env(REQUIRED_ENV_VARS)
+    except ConfigurationError as exc:
+        raise InitializationError("environment loading failed") from exc
+
+    try:
+        embedder = await asyncio.to_thread(BgeEmbedder)
+    except Exception as exc:  # noqa: BLE001
+        raise InitializationError("embedder initialization failed") from exc
+
+    try:
+        index = await asyncio.to_thread(PineconeIndex)
+    except Exception as exc:  # noqa: BLE001
+        raise InitializationError("index initialization failed") from exc
+
+    return build_interface(embedder, index)
+
+
+def main() -> None:
+    """Launch the Gradio chat interface."""
+    try:
+        interface = asyncio.run(startup())
+        interface.launch()
+    except Exception as exc:  # noqa: BLE001
+        raise InitializationError("application startup failed") from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main_smoke.py
+++ b/tests/test_main_smoke.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from src.exceptions import InitializationError
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.mark.asyncio
+async def test_startup_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PINECONE_API_KEY", "key")
+    monkeypatch.setenv("PINECONE_INDEX_NAME", "index")
+    monkeypatch.setitem(
+        sys.modules,
+        "dotenv",
+        types.SimpleNamespace(load_dotenv=lambda _: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "pinecone",
+        types.SimpleNamespace(Pinecone=object, ServerlessSpec=object),
+    )
+    main = importlib.reload(importlib.import_module("src.main"))
+
+    dummy_interface = object()
+    monkeypatch.setattr(main, "BgeEmbedder", lambda: object())
+    monkeypatch.setattr(main, "PineconeIndex", lambda: object())
+    monkeypatch.setattr(main, "build_interface", lambda e, i: dummy_interface)
+
+    interface = await main.startup()
+    assert interface is dummy_interface
+
+
+@pytest.mark.asyncio
+async def test_startup_missing_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "dotenv",
+        types.SimpleNamespace(load_dotenv=lambda _: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "pinecone",
+        types.SimpleNamespace(Pinecone=object, ServerlessSpec=object),
+    )
+    main = importlib.reload(importlib.import_module("src.main"))
+
+    monkeypatch.delenv("PINECONE_API_KEY", raising=False)
+    monkeypatch.delenv("PINECONE_INDEX_NAME", raising=False)
+    with pytest.raises(InitializationError):
+        await main.startup()


### PR DESCRIPTION
## Summary
- add async startup to launch Gradio interface with env loading
- introduce InitializationError for startup failures
- verify startup via smoke tests without external services

## Testing
- `black src/ tests/ scripts/` *(fails: Path 'scripts/' does not exist)*
- `black src/ tests/`
- `flake8 src/ tests/` *(fails: line length and import issues in existing files)*
- `flake8 src/main.py src/exceptions.py tests/test_main_smoke.py`
- `mypy src/main.py src/exceptions.py` *(fails: missing stubs and other module errors)*
- `python scripts/check_code_quality.py` *(fails: file not found)*
- `pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68ade06077888322aaf9eaacad2a2406