### PR TITLE
ci: enforce coverage threshold

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests with coverage
+        run: pytest --cov=src --cov-fail-under=80

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ technical debt and code duplication.
 - Never hardcode API keys; load them from environment variables.
 - Write tests for all new code and aim for at least 80% coverage while mocking
   external services.
-- Run `python scripts/check_code_quality.py` and `pytest tests/ -v` before
+- Run `python scripts/check_code_quality.py` and `pytest --cov=src --cov-fail-under=80 tests/ -v` before
   committing.
 - Use Conventional Commits for messages and ensure branches are up to date with
   `main`.
 
 ## Testing
-Run unit tests with coverage:
+Run unit tests with coverage enforcement:
 ```bash
-pytest --cov=src tests/
+pytest --cov=src --cov-fail-under=80 tests/
 ```
 Run code quality checks:
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,9 +34,9 @@ The retrieval strategy is informed by Dense X Retrieval research, enabling propo
    ```
 
 ## Testing Commands
-- Run tests with coverage:
+- Run tests with coverage enforcement:
   ```bash
-  pytest --cov=src tests/
+  pytest --cov=src --cov-fail-under=80 tests/
   ```
 - Run code quality checks:
   ```bash
@@ -47,7 +47,7 @@ The retrieval strategy is informed by Dense X Retrieval research, enabling propo
 - Follow PEP 8 with functions under 30 lines and full type hints.
 - Use async/await for I/O and validate inputs.
 - Ensure tests cover new code (≥80% coverage) and mock external APIs.
-- Run `python scripts/check_code_quality.py` and `pytest tests/ -v` before committing.
+- Run `python scripts/check_code_quality.py` and `pytest --cov=src --cov-fail-under=80 tests/ -v` before committing.
 - Use Conventional Commit messages and keep branches updated with `main`.
 
 ## Future Documentation

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=src --cov-fail-under=80

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ PyPDF2>=3.0.0
 # Testing and code quality tools
 pytest>=7.0
 pytest-asyncio>=0.21
+pytest-cov>=4.0
 mypy>=1.0
 black>=23.0
 flake8>=6.0

--- a/scripts/check_code_quality.py
+++ b/scripts/check_code_quality.py
@@ -1,0 +1,54 @@
+"""Run code quality checks including coverage tests."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Sequence
+
+
+class QualityCheckError(Exception):
+    """Raised when a quality check command fails."""
+
+
+async def run_command(cmd: Sequence[str]) -> None:
+    """Run a single command asynchronously."""
+    process = await asyncio.create_subprocess_exec(*cmd)
+    await process.communicate()
+    if process.returncode != 0:
+        raise QualityCheckError(
+            f"Command {' '.join(cmd)} failed with exit code {process.returncode}"
+        )
+
+
+async def run_checks(commands: Sequence[Sequence[str]] | None = None) -> None:
+    """Run standard quality checks or provided commands."""
+    cmds = commands or [
+        ["black", "src", "tests", "scripts"],
+        [
+            "flake8",
+            "--max-line-length=100",
+            "--extend-ignore=E203,E402",
+            "src",
+            "tests",
+        ],
+        ["pytest"],
+    ]
+    for cmd in cmds:
+        try:
+            await run_command(cmd)
+        except QualityCheckError as exc:
+            print(exc)
+            raise
+
+
+def main() -> None:
+    """Entry point for running quality checks."""
+    try:
+        asyncio.run(run_checks())
+    except QualityCheckError:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openrouter_client.py
+++ b/src/openrouter_client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 from typing import Any, Optional
 

--- a/tests/test_check_code_quality.py
+++ b/tests/test_check_code_quality.py
@@ -1,0 +1,14 @@
+import pytest
+
+from scripts.check_code_quality import QualityCheckError, run_checks
+
+
+@pytest.mark.asyncio
+async def test_run_checks_success() -> None:
+    await run_checks([["python", "-c", "print('ok')"]])
+
+
+@pytest.mark.asyncio
+async def test_run_checks_failure() -> None:
+    with pytest.raises(QualityCheckError):
+        await run_checks([["python", "-c", "import sys; sys.exit(1)"]])

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,10 +1,6 @@
 import asyncio
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from src.exceptions import RetryError
 from src.utils import retry


### PR DESCRIPTION
## Summary
- enforce 80% coverage via pytest.ini and CI workflow
- add asynchronous quality check script and tests
- document running coverage before commits

## Testing
- `python scripts/check_code_quality.py`
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_68ade3655e90832295c6c99236e6ee65