### PR TITLE
refactor: split async retry helpers

### DIFF
--- a/src/utils/retry.py
+++ b/src/utils/retry.py
@@ -3,11 +3,64 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Awaitable, Callable, TypeVar, Type
+from typing import Awaitable, Callable, Type, TypeVar
 
 from ..exceptions import RetryError
 
 T = TypeVar("T")
+
+
+def _validate_params(
+    *,
+    max_attempts: int,
+    base_delay: float,
+    timeout: float,
+    error_cls: Type[Exception],
+) -> None:
+    """Validate retry parameters.
+
+    Args:
+        max_attempts: Maximum number of attempts before failing.
+        base_delay: Initial backoff delay in seconds.
+        timeout: Per-attempt timeout in seconds.
+        error_cls: Exception type raised for invalid parameters.
+
+    Raises:
+        error_cls: If provided parameters are invalid.
+    """
+    if max_attempts < 1 or base_delay <= 0 or timeout <= 0:
+        raise error_cls("invalid retry parameters")
+
+
+async def _run_with_retry(
+    func: Callable[[], Awaitable[T]],
+    *,
+    max_attempts: int,
+    base_delay: float,
+    timeout: float,
+    error_cls: Type[Exception],
+) -> T:
+    """Execute an async callable with retry logic.
+
+    Args:
+        func: Async callable with no arguments.
+        max_attempts: Maximum number of attempts before failing.
+        base_delay: Initial backoff delay in seconds.
+        timeout: Per-attempt timeout in seconds.
+        error_cls: Exception type raised after final failure.
+    Returns:
+        Result of the callable if successful.
+    Raises:
+        error_cls: If all attempts fail or timeout occurs.
+    """
+    for attempt in range(max_attempts):
+        try:
+            return await asyncio.wait_for(func(), timeout=timeout)
+        except Exception as exc:  # noqa: BLE001
+            if attempt == max_attempts - 1:
+                raise error_cls("operation failed after retries") from exc
+            await asyncio.sleep(base_delay * 2**attempt)
+    raise error_cls("operation failed after retries")
 
 
 async def async_retry(
@@ -19,27 +72,27 @@ async def async_retry(
     error_cls: Type[Exception] = RetryError,
 ) -> T:
     """Retry an async callable with exponential backoff and timeout.
-
     Args:
         func: Async callable with no arguments.
         max_attempts: Maximum number of attempts before failing.
         base_delay: Initial backoff delay in seconds.
         timeout: Per-attempt timeout in seconds.
         error_cls: Exception type raised after final failure.
-
     Returns:
         Result of the callable if successful.
-
     Raises:
         error_cls: If all attempts fail or timeout occurs.
     """
-    if max_attempts < 1 or base_delay <= 0 or timeout <= 0:
-        raise error_cls("invalid retry parameters")
-    for attempt in range(max_attempts):
-        try:
-            return await asyncio.wait_for(func(), timeout=timeout)
-        except Exception as exc:  # noqa: BLE001
-            if attempt == max_attempts - 1:
-                raise error_cls("operation failed after retries") from exc
-            await asyncio.sleep(base_delay * 2**attempt)
-    raise error_cls("operation failed after retries")
+    _validate_params(
+        max_attempts=max_attempts,
+        base_delay=base_delay,
+        timeout=timeout,
+        error_cls=error_cls,
+    )
+    return await _run_with_retry(
+        func,
+        max_attempts=max_attempts,
+        base_delay=base_delay,
+        timeout=timeout,
+        error_cls=error_cls,
+    )

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -52,3 +52,12 @@ async def test_async_retry_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(retry.asyncio, "sleep", fake_sleep)
     with pytest.raises(RetryError):
         await retry.async_retry(never, max_attempts=2, timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_async_retry_invalid_params() -> None:
+    async def noop() -> None:
+        pass
+
+    with pytest.raises(RetryError):
+        await retry.async_retry(noop, max_attempts=0)


### PR DESCRIPTION
## Summary
- refactor async_retry into validation and retry helpers
- test retry parameter validation

## Testing
- `uv run black src/utils/retry.py tests/test_retry.py`
- `uv run isort src/utils/retry.py tests/test_retry.py`
- `uv run flake8 src tests`
- `make check` *(fails: No rule to make target 'check')*
- `uv run pytest tests/ -v --cov=src`


------
https://chatgpt.com/codex/tasks/task_e_68adf30db5908322886719f24904ab13