### PR TITLE
fix: derive custom exceptions from GradioError

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -2,38 +2,48 @@
 
 from __future__ import annotations
 
+# Use Gradio's base error type when available; provide a fallback otherwise.
+try:  # pragma: no cover - import guard
+    from gradio.exceptions import GradioError
+except Exception:  # pragma: no cover - gradio missing or outdated
 
-class DocumentParsingError(Exception):
+    class GradioError(Exception):
+        """Fallback base error when GradioError cannot be imported."""
+
+        pass
+
+
+class DocumentParsingError(GradioError):
     """Raised when a document cannot be parsed for Dense X Retrieval."""
 
 
-class EmbeddingError(Exception):
+class EmbeddingError(GradioError):
     """Raised when embedding generation fails in Dense X Retrieval."""
 
 
-class IndexingError(Exception):
+class IndexingError(GradioError):
     """Raised when Pinecone index operations fail in Dense X Retrieval."""
 
 
-class ChatError(Exception):
+class ChatError(GradioError):
     """Raised for chat interface issues in Dense X Retrieval."""
 
 
-class MonitoringError(Exception):
+class MonitoringError(GradioError):
     """Raised when cost monitoring fails or budget exceeded."""
 
 
-class OpenRouterError(Exception):
+class OpenRouterError(GradioError):
     """Raised when OpenRouter API calls fail."""
 
 
-class CitationError(Exception):
+class CitationError(GradioError):
     """Raised when citation generation fails."""
 
 
-class RetryError(Exception):
+class RetryError(GradioError):
     """Raised when an operation exceeds retry attempts."""
 
 
-class InitializationError(Exception):
+class InitializationError(GradioError):
     """Raised when application startup fails."""


### PR DESCRIPTION
## Summary
- use GradioError as base for custom exceptions with a safe fallback
- ensure all custom exceptions inherit from GradioError

## Testing
- `uv run flake8 src tests` *(fails: line length errors across repository)*
- `uv tool run bandit -r src`
- `PYTHONPATH=. uv run pytest tests/test_retry.py -v -o addopts=`
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_68adf4e588588322ab39dfa3b4ec62ee