### PR TITLE
fix: add retry to usage monitor dashboard logging

### DIFF
--- a/src/monitoring/usage_monitor.py
+++ b/src/monitoring/usage_monitor.py
@@ -12,6 +12,7 @@ import aiofiles  # type: ignore[import-not-found,import-untyped]
 import httpx  # type: ignore[import-not-found]
 
 from ..exceptions import MonitoringError
+from ..utils.retry import async_retry
 
 
 @dataclass
@@ -26,6 +27,12 @@ class UsageMonitor:
     )
     dashboard_url: Optional[str] = field(
         default_factory=lambda: os.getenv("MONITOR_DASHBOARD_URL")
+    )
+    dashboard_retries: int = field(
+        default_factory=lambda: int(os.getenv("MONITOR_DASHBOARD_RETRIES", "3"))
+    )
+    dashboard_timeout: float = field(
+        default_factory=lambda: float(os.getenv("MONITOR_DASHBOARD_TIMEOUT", "5"))
     )
     totals: Dict[str, float] = field(default_factory=dict)
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
@@ -43,24 +50,41 @@ class UsageMonitor:
             self.totals[service] = self.totals.get(service, 0.0) + cost
             await self._log(service, cost)
             if self.totals[service] >= self.alert_limit:
-                msg = f"{service} cost {self.totals[service]:.2f} exceeds ${self.alert_limit:.2f}"
+                msg = (
+                    f"{service} cost {self.totals[service]:.2f} exceeds "
+                    f"${self.alert_limit:.2f}"
+                )
                 raise MonitoringError(msg)
 
     async def _log(self, service: str, cost: float) -> None:
         """Persist cost data to CSV and optional dashboard."""
-        row = f"{datetime.utcnow().isoformat()},{service},{cost:.4f},{self.totals[service]:.4f}\n"
+        row = (
+            f"{datetime.utcnow().isoformat()},{service},{cost:.4f},"
+            f"{self.totals[service]:.4f}\n"
+        )
         try:
             async with aiofiles.open(self.log_path, "a") as f:
                 await f.write(row)
-            if self.dashboard_url:
-                async with httpx.AsyncClient(timeout=5) as client:
-                    await client.post(
-                        self.dashboard_url,
-                        json={
-                            "service": service,
-                            "cost": cost,
-                            "total": self.totals[service],
-                        },
-                    )
+        except Exception as exc:  # noqa: BLE001
+            raise MonitoringError("failed to log usage") from exc
+
+        if not self.dashboard_url:
+            return
+
+        payload = {
+            "service": service,
+            "cost": cost,
+            "total": self.totals[service],
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self.dashboard_timeout) as client:
+                await async_retry(
+                    lambda: client.post(self.dashboard_url, json=payload),
+                    max_attempts=self.dashboard_retries,
+                    timeout=self.dashboard_timeout,
+                    error_cls=MonitoringError,
+                )
+        except MonitoringError:
+            raise
         except Exception as exc:  # noqa: BLE001
             raise MonitoringError("failed to log usage") from exc

--- a/tests/test_usage_monitor.py
+++ b/tests/test_usage_monitor.py
@@ -1,16 +1,18 @@
+import importlib
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
-import importlib
+import httpx
 import pytest
 
 sys.modules.pop("aiofiles", None)
 aiofiles = importlib.import_module("aiofiles")
 sys.modules["aiofiles"] = aiofiles
 
-from src.monitoring import UsageMonitor  # noqa: E402
 from src.exceptions import MonitoringError  # noqa: E402
+from src.monitoring import UsageMonitor  # noqa: E402
 
 
 @pytest.mark.asyncio
@@ -26,3 +28,58 @@ async def test_monitor_logs_and_alerts(tmp_path: Path) -> None:
         await monitor.record("pinecone", 0.2)
     with open(log) as f:
         assert len(f.readlines()) == 3
+
+
+@pytest.mark.asyncio
+async def test_dashboard_retry_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls = 0
+
+    async def fail_post(self: httpx.AsyncClient, url: str, json: Any) -> None:
+        nonlocal calls
+        calls += 1
+        raise httpx.HTTPError("boom")
+
+    async def no_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fail_post)
+    monkeypatch.setattr("asyncio.sleep", no_sleep)
+    monkeypatch.setenv("MONITOR_LOG_PATH", str(tmp_path / "log.csv"))
+    monkeypatch.setenv("MONITOR_DASHBOARD_URL", "http://dash")
+    monkeypatch.setenv("MONITOR_DASHBOARD_RETRIES", "2")
+    monkeypatch.setenv("MONITOR_DASHBOARD_TIMEOUT", "0.01")
+    monitor = UsageMonitor()
+    with pytest.raises(MonitoringError):
+        await monitor.record("svc", 0.1)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_dashboard_retry_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls = 0
+
+    async def flaky_post(
+        self: httpx.AsyncClient, url: str, json: Any
+    ) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls < 2:
+            raise httpx.HTTPError("boom")
+        return httpx.Response(200)
+
+    async def no_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", flaky_post)
+    monkeypatch.setattr("asyncio.sleep", no_sleep)
+    monkeypatch.setenv("MONITOR_LOG_PATH", str(tmp_path / "log.csv"))
+    monkeypatch.setenv("MONITOR_DASHBOARD_URL", "http://dash")
+    monkeypatch.setenv("MONITOR_DASHBOARD_RETRIES", "3")
+    monkeypatch.setenv("MONITOR_DASHBOARD_TIMEOUT", "0.01")
+    monitor = UsageMonitor()
+    await monitor.record("svc", 0.1)
+    assert calls == 2


### PR DESCRIPTION
## Summary
- add configurable retries and timeout for usage monitor dashboard logging
- handle MonitoringError on final retry failure
- add tests for dashboard retry success and failure

## Testing
- `uv run flake8 --max-line-length=88 src/monitoring/usage_monitor.py tests/test_usage_monitor.py`
- `uv run pytest tests/ -v --cov=src`


------
https://chatgpt.com/codex/tasks/task_e_68adfee2f78883228a5ebc4c14c3daa7