### PR TITLE
refactor: use async_retry in chat interface

### DIFF
--- a/src/chat_interface.py
+++ b/src/chat_interface.py
@@ -2,29 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
-from typing import Awaitable, Callable, List, TypeVar
+from typing import List
 
 import gradio as gr  # type: ignore[import-not-found]
 
 from .embedder import BgeEmbedder
-from .exceptions import ChatError
+from .exceptions import ChatError, RetryError
 from .pinecone_index import PineconeIndex
-
-T = TypeVar("T")
-
-
-async def _with_retry(
-    func: Callable[[], Awaitable[T]], retries: int = 3, timeout: int = 10
-) -> T:
-    """Execute an async function with retry and timeout."""
-    for attempt in range(retries):
-        try:
-            return await asyncio.wait_for(func(), timeout=timeout)
-        except Exception:
-            if attempt == retries - 1:
-                raise
-            await asyncio.sleep(0.5)
+from .utils.retry import async_retry
 
 
 async def handle_message(
@@ -34,19 +19,28 @@ async def handle_message(
     if not isinstance(message, str) or not message.strip():
         raise ChatError("message must be a non-empty string")
     try:
-        vectors = await _with_retry(lambda: embedder.embed([message]))
-    except Exception as exc:  # noqa: BLE001
+        vectors = await async_retry(
+            lambda: embedder.embed([message]),
+            timeout=10.0,
+        )
+    except RetryError as exc:
         raise ChatError("embedding failed") from exc
     try:
-        results = await _with_retry(lambda: index.query(vectors[0]))
-    except Exception as exc:  # noqa: BLE001
+        results = await async_retry(
+            lambda: index.query(vectors[0]),
+            timeout=10.0,
+        )
+    except RetryError as exc:
         raise ChatError("index query failed") from exc
     if not results:
         return "No results found."
     return results[0]["metadata"].get("text", "")
 
 
-def build_interface(embedder: BgeEmbedder, index: PineconeIndex) -> gr.ChatInterface:
+def build_interface(
+    embedder: BgeEmbedder,
+    index: PineconeIndex,
+) -> gr.ChatInterface:
     """Construct a Gradio chat interface for Dense X Retrieval."""
 
     async def responder(message: str, history: List[List[str]]) -> str:


### PR DESCRIPTION
## Summary
- replace bespoke `_with_retry` helper with shared `async_retry`
- map retry failures to `ChatError`
- extend chat interface tests for retry success and failure

## Testing
- `uv run flake8 src/chat_interface.py tests/test_chat_interface.py`
- `uv run --with pytest-cov pytest tests/ -v --cov=src`
- `uv run flake8 src tests` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0323716c8322aff53dd182a6b07a